### PR TITLE
Added statuses for patterns

### DIFF
--- a/app/assets/sass/hacks/_hacks.scss
+++ b/app/assets/sass/hacks/_hacks.scss
@@ -1,2 +1,3 @@
 @import "iframeresize";
 @import "examples";
+@import "status";

--- a/app/assets/sass/hacks/_status.scss
+++ b/app/assets/sass/hacks/_status.scss
@@ -1,0 +1,13 @@
+.status-metadata {
+  font-size: 14px;
+  line-height: 1.42857;
+  margin-bottom: 30px;
+
+  dl dt {
+    float: left;
+    clear: left;
+    width: auto;
+    min-width: 130px;
+    padding-right: 10px;
+  }
+}

--- a/app/assets/sass/hacks/_status.scss
+++ b/app/assets/sass/hacks/_status.scss
@@ -1,4 +1,4 @@
-.status-metadata {
+.hack_status-metadata {
   font-size: 14px;
   line-height: 1.42857;
   margin-bottom: 30px;

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,6 +1,7 @@
 {% extends "govuk_tech_docs_template.html" %}
 {% from "macros/nav.html" import nav as navMenu %}
 {% from "macros/iframe.html" import iframe %}
+{% from "macros/status.html" import statusHeader, statusFooter %}
 
 {% block nav %}
   {{ navMenu(section, page) }}

--- a/app/views/macros/status.html
+++ b/app/views/macros/status.html
@@ -1,0 +1,29 @@
+{% macro statusHeader(currentStatus, author ,discussedOn, editedOn) %}
+<div class="status-metadata">
+  <dl>
+    <dt>Status:</dt>
+    <dd><a href="#">{{ currentStatus }}</a></dd>
+    <dt>Author:</dt>
+    <dd><a href="#">{{ author }}</a></dd>
+    <dt>Discuss on:</dt>
+    <dd><a href="#">{{ discussedOn }}</a></dd>
+    <dt>Edit on:</dt>
+    <dd><a href="#">{{ editedOn }}</a></dd>
+  </dl>
+</div>
+{% endmacro %}
+
+{% macro statusFooter(inPrototype, inAssetsFrontEnd, firstSubmitted, lastUpdated) %}
+  <div class="status-metadata">
+    <dl>
+      <dt>In prototype kit:</dt>
+      <dd>{{ inPrototype }}</dd>
+      <dt>In Assets Front End:</dt>
+      <dd>{{ inAssetsFrontEnd }}</dd>
+      <dt>First submitted:</dt>
+      <dd>{{ firstSubmitted }}</dd>
+      <dt>Last updated:</dt>
+      <dd>{{ lastUpdated }}</dd>
+    </dl>
+  </div>
+{% endmacro %}

--- a/app/views/macros/status.html
+++ b/app/views/macros/status.html
@@ -1,5 +1,5 @@
-{% macro statusHeader(currentStatus, author ,discussedOn, editedOn) %}
-<div class="status-metadata">
+{% macro statusHeader(currentStatus, author, discussedOn, editedOn) %}
+<div class="hack_status-metadata">
   <dl>
     <dt>Status:</dt>
     <dd><a href="#">{{ currentStatus }}</a></dd>
@@ -14,7 +14,7 @@
 {% endmacro %}
 
 {% macro statusFooter(inPrototype, inAssetsFrontEnd, firstSubmitted, lastUpdated) %}
-  <div class="status-metadata">
+  <div class="hack_status-metadata">
     <dl>
       <dt>In prototype kit:</dt>
       <dd>{{ inPrototype }}</dd>

--- a/app/views/patterns/header/govuk-header.html
+++ b/app/views/patterns/header/govuk-header.html
@@ -16,12 +16,9 @@ GOV.UK prototype kit
 
     <h2 class="heading-medium">When to use this pattern</h2>
     <p>This pattern should be used on all service pages.</p>
-
     <!-- /patterns/header/govuk_header_partial -->
     <h3 class="heading-small">Example</h3>
-
     {{ iframe('/patterns/header/govuk_header_partial.html') }}
-
     <p>
       <a href="/docs/examples/blank-govuk.html">View the header in a page</a>
     </p>
@@ -39,4 +36,6 @@ GOV.UK prototype kit
       Discuss this pattern on
       <a href="https://github.com/hmrc/design-language-documentation/issues/4">GitHub</a>
     </p>
+  </div>
+</div>
 {% endblock %}

--- a/app/views/patterns/header/phase-banner.html
+++ b/app/views/patterns/header/phase-banner.html
@@ -14,18 +14,39 @@
       <h3 class="heading-small">Examples</h3>
 
       <h4>Alpha banner</h4>
-      {{ statusHeader('Backlog', 'Service Design Tools', 'Hackpad', 'Github') }}
+
+      {{ statusHeader(
+      currentStatus='Backlog',
+      author='HMRC',
+      discussedOn='Hackpad',
+      editedOn='Github'
+      ) }}
 
       {{ iframe('/patterns/header/alpha_banner_partial.html') }}
 
-      {{ statusFooter('No', 'No', '15/06/2016', '28/02/2017') }}
+      {{ statusFooter(
+      inPrototype='No',
+      inAssetsFrontEnd='No',
+      firstSubmitted='15/06/2016',
+      lastUpdated='28/02/2017'
+      ) }}
 
       <h4>Beta banner</h4>
-      {{ statusHeader('Backlog', 'Service Design Tools', 'Hackpad', 'Github') }}
+      {{ statusHeader(
+      currentStatus='Backlog',
+      author='HMRC',
+      discussedOn='Hackpad',
+      editedOn='Github'
+      ) }}
 
       {{ iframe('/patterns/header/beta_banner_partial.html') }}
 
-      {{ statusFooter('No', 'No', '15/06/2016', '28/02/2017') }}
+      {{ statusFooter(
+      inPrototype='No',
+      inAssetsFrontEnd='No',
+      firstSubmitted='15/06/2016',
+      lastUpdated='28/02/2017'
+      ) }}
       <hr>
       <p>
         Discuss this pattern on

--- a/app/views/patterns/header/phase-banner.html
+++ b/app/views/patterns/header/phase-banner.html
@@ -1,29 +1,38 @@
 {% extends "layout.html" %} {% block page_title %} GOV.UK prototype kit {% endblock %} {% set currentSection = 'header' %} {% set currentPage = 'govUkHeader' %} {% block content %}
 
-<div class="grid-row">
-  <div class="column-full">
+  <div class="grid-row">
+    <div class="column-full">
 
-    <h1 class="heading-xlarge">
-      <span class="heading-secondary">Header</span>
-      Phase banner
-    </h1>
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">Header</span>
+        Phase banner
+      </h1>
 
-    <h2 class="heading-medium">When to use this pattern</h2>
-    <p>This pattern should be used on all service pages unless the service has passed it's live assessment.</p>
+      <h2 class="heading-medium">When to use this pattern</h2>
+      <p>This pattern should be used on all service pages unless the service has passed it's live assessment.</p>
 
-    <h3 class="heading-small">Examples</h3>
+      <h3 class="heading-small">Examples</h3>
 
-    <h4>Alpha banner</h4>
-    {{ iframe('/patterns/header/alpha_banner_partial.html') }}
-    <h4>Beta banner</h4>
-    {{ iframe('/patterns/header/beta_banner_partial.html') }}
-    <hr>
-    <p>
-      Discuss this pattern on
-      <a href="https://github.com/hmrc/design-language-documentation/issues/4">GitHub</a>
-    </p>
+      <h4>Alpha banner</h4>
+      {{ statusHeader('Backlog', 'Service Design Tools', 'Hackpad', 'Github') }}
 
+      {{ iframe('/patterns/header/alpha_banner_partial.html') }}
+
+      {{ statusFooter('No', 'No', '15/06/2016', '28/02/2017') }}
+
+      <h4>Beta banner</h4>
+      {{ statusHeader('Backlog', 'Service Design Tools', 'Hackpad', 'Github') }}
+
+      {{ iframe('/patterns/header/beta_banner_partial.html') }}
+
+      {{ statusFooter('No', 'No', '15/06/2016', '28/02/2017') }}
+      <hr>
+      <p>
+        Discuss this pattern on
+        <a href="https://github.com/hmrc/design-language-documentation/issues/4">GitHub</a>
+      </p>
+
+    </div>
   </div>
-</div>
 
 {% endblock %}


### PR DESCRIPTION
## Problem
When viewing patterns you should be able to know what its current status is, when it was created, who created it and where its being discussed. Currently no status information is showing on patterns.


## Solution

Create a macro that can be added around the iframe to provide the status information

![screen shot 2017-03-13 at 11 30 23](https://cloud.githubusercontent.com/assets/10154302/23852591/8229487c-07e0-11e7-90ca-ed2bb9f04dca.png)
